### PR TITLE
fix: replace deprecated accessors

### DIFF
--- a/Source/RtspDisplay/RtspClientComponent.cpp
+++ b/Source/RtspDisplay/RtspClientComponent.cpp
@@ -54,11 +54,11 @@ void URtspClientComponent::TickComponent(float DeltaTime, enum ELevelTick TickTy
   // create a texture
   auto texture = UTexture2D::CreateTransient(width, height, PF_B8G8R8A8);
   // lock the texture
-  uint8 *mip_data = static_cast<uint8 *>(texture->PlatformData->Mips[0].BulkData.Lock(LOCK_READ_WRITE));
+  uint8 *mip_data = static_cast<uint8 *>(texture->GetPlatformData()->Mips[0].BulkData.Lock(LOCK_READ_WRITE));
   // copy the jpeg data into the texture
   std::copy(data.data(), data.data() + data.size(), mip_data);
   // unlock the texture
-  texture->PlatformData->Mips[0].BulkData.Unlock();
+  texture->GetPlatformData()->Mips[0].BulkData.Unlock();
   // update the texture
   texture->UpdateResource();
   // broadcast the texture


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
* Replace deprecated PlatformData accessor with updated API GetPlatformData() accessor.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Prior to this PR, when building the code you'd get these warnings:
<img width="844" alt="CleanShot 2023-07-30 at 09 47 05@2x" src="https://github.com/finger563/unreal-rtsp-display/assets/213467/2dd476de-d833-4486-9c98-5b33d0e50be8">

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Building the code.

## Screenshots (if appropriate, e.g. schematic, board, console logs, lab pictures):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update
- [x] Software change

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] My change requires a change to the documentation.
- [ ] I have added / updated the documentation related to this change via either README or WIKI

### Software
<!-- Delete this section if not relevant to your PR  -->
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] My code follows the code style of this project.
